### PR TITLE
fix: Move the custom styles after the base primevue styles

### DIFF
--- a/src/components/nuxt/index.js
+++ b/src/components/nuxt/index.js
@@ -10,9 +10,9 @@ export default function (moduleOptions) {
         themePath = theme;
     }
 
-    this.options.css.push(themePath);
     this.options.css.push('@curbsidesos/primevue/resources/primevue.min.css');
     this.options.css.push('primeicons/primeicons.css');
+    this.options.css.push(themePath);
 
     if (config.ripple) {
         this.addPlugin(path.resolve(__dirname, '../config/plugin-ripple.js'));


### PR DESCRIPTION
### Defect Fixes
Currently the primevue styles are overwriting the custom theme or specific team created by the client. So, this doesn't make sense, the custom styles must go after the base styles.